### PR TITLE
Fix realm name

### DIFF
--- a/authentic/pi.authentic.php
+++ b/authentic/pi.authentic.php
@@ -36,7 +36,7 @@ class Authentic {
      * @param string -- the security "realm" displayed in the 401 pop-up
      */
     public static function challenge($realm) {
-        header("WWW-Authenticate: Basic realm='$realm'");
+        header("WWW-Authenticate: Basic realm=\"{$realm}\"");
         header('HTTP/1.0 401 Unauthorized');
         exit('Authentication is required to view this page.');
     }


### PR DESCRIPTION
With single quotes around a realm name containing a space, the realm name is truncated to end with the character before the first space. For example, `realm='Realm name'` results in `'Realm` being displayed in the authentication prompt.
